### PR TITLE
Add timeout to our branch of the mandrill library.

### DIFF
--- a/mandrill.py
+++ b/mandrill.py
@@ -156,7 +156,12 @@ class Mandrill(object):
         params = json.dumps(params)
         self.log('POST to %s%s.json: %s' % (ROOT, url, params))
         start = time.time()
-        r = self.session.post('%s%s.json' % (ROOT, url), data=params, headers={'content-type': 'application/json', 'user-agent': 'Mandrill-Python/1.0.58'})
+        r = self.session.post(
+            '%s%s.json' % (ROOT, url),
+            data=params,
+            headers={'content-type': 'application/json', 'user-agent': 'Mandrill-Python/1.0.58'},
+            timeout=5,  # seconds
+        )
         try:
             remote_addr = r.raw._original_response.fp._sock.getpeername() # grab the remote_addr before grabbing the text since the socket will go away
         except:


### PR DESCRIPTION
We could also do it at the session level.

Not sure how much we want to alter the mandrill library, deal with the maintenance over head, but the docs to requests do note:

http://docs.python-requests.org/en/master/user/quickstart/#timeouts